### PR TITLE
UI prompt that asks for permission to use Strap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,17 @@ Success! You've successfully integrated Strap into your Pebble application. We'l
      - uncomment ```#define DISABLE_ACCL``` in strap.h
 
 ##User Opt-Out
+   We provide an easy way for you to allow your users to opt-out of being tracked. Use this simple function which will push a new window asking the user for permission. Call it at either the end of init() or put it in a click handler using:
+   ```
+   prompt_opt_out(default_selection);
+   ```
+   default_selection is a boolean which, when true, automatically highlights "Yes", and, when false, highlights "No". Here is what the prompt looks like:
+   
+   ![alt text](https://github.com/cheniel/strap-optout-prompt-test/raw/master/screenshots/screenshot.png "Prompt Screenshot")
 
-
-   We provide an easy way for you to allow your users to opt-out of being tracked. Just set the following persistent storage variable and we will not report any data. You could set this through your configuration page, or with a simple UI prompt on the Pebble when the user first loads the app. If you make a useful UI element for this, consider creating a pull request so we can make this process even easier for devs.
+   If you would rather create your own interface for prompting the user, just set the following persistent storage variable and we will not report any data. You could set this through your configuration page, or with a simple UI prompt on the Pebble when the user first loads the app.
 
    ```
    set_persist_bool(STRAP_OPT_OUT,true);
    ```
-
-
+   

--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ Success! You've successfully integrated Strap into your Pebble application. We'l
      - uncomment ```#define DISABLE_ACCL``` in strap.h
 
 ##User Opt-Out
+   ![alt text](https://github.com/cheniel/strap-optout-prompt-test/raw/master/screenshots/screenshot.png "Prompt Screenshot")
+   
    We provide an easy way for you to allow your users to opt-out of being tracked. Use this simple function which will push a new window asking the user for permission. Call it at either the end of init() or put it in a click handler using:
    ```
    prompt_opt_out(default_selection);
    ```
-   default_selection is a boolean which, when true, automatically highlights "Yes", and, when false, highlights "No". Here is what the prompt looks like:
-   
-   ![alt text](https://github.com/cheniel/strap-optout-prompt-test/raw/master/screenshots/screenshot.png "Prompt Screenshot")
+   default_selection is a boolean which, when true, automatically highlights "Yes", and, when false, highlights "No". If the user presses the back button on the prompt, Strap metrics are disabled. 
 
    If you would rather create your own interface for prompting the user, just set the following persistent storage variable and we will not report any data. You could set this through your configuration page, or with a simple UI prompt on the Pebble when the user first loads the app.
 

--- a/src/c/strap.c
+++ b/src/c/strap.c
@@ -19,6 +19,16 @@
 static int report_accl = 0;
 static char cur_activity[15];
 
+#define PROMPT_ANIMATED true
+#define PROMPT_USER "Allow this app to gather anonymous usage metrics?\n\n\n\n\n\n\nstraphq.com"
+#define PROMPT_YES_BUTTON "Yes"
+#define PROMPT_NO_BUTTON "No"
+static Window* prompt;
+static bool prompt_selected_yes;
+static bool prompt_select_pressed = false;
+static TextLayer *prompt_question;
+static TextLayer *prompt_yes;
+static TextLayer *prompt_no;
 
 #define LOG_ROWS 30
 #define LOG_COLS 50
@@ -37,6 +47,16 @@ static void app_timer_battery(void*);
 static void appendLog(char*);
 static void send_next_log(void*);
 static bool is_log_available();
+static void highlight_prompt_selection();
+static void prompt_load(Window *window);
+static void prompt_unload(Window *window);
+static void prompt_click_config_provider(void *context);
+static void prompt_select_click_handler(ClickRecognizerRef recognizer,
+                                        void *context);
+static void prompt_up_click_handler(ClickRecognizerRef recognizer,
+                                    void *context);
+static void prompt_down_click_handler(ClickRecognizerRef recognizer,
+                                      void *context);
 
 #ifdef DEBUG
 static char* translate_error(AppMessageResult);
@@ -286,4 +306,102 @@ void strap_set_activity(char* act) {
 
 void strap_set_freq(int freq) {
     curFreq = freq;
+}
+
+static void highlight_prompt_selection() {
+    TextLayer *to_highlight = prompt_selected_yes ? prompt_yes : prompt_no;
+    TextLayer *unhighlight = prompt_selected_yes ? prompt_no : prompt_yes;
+
+    text_layer_set_background_color(to_highlight, GColorBlack);
+    text_layer_set_background_color(unhighlight, GColorWhite);
+
+    text_layer_set_text_color(to_highlight, GColorWhite);
+    text_layer_set_text_color(unhighlight, GColorBlack);
+}
+
+static void prompt_load(Window *window) {
+    prompt_select_pressed = false;
+    Layer *window_layer = window_get_root_layer(window);
+
+    prompt_question = text_layer_create((GRect) {
+        .origin = { 9, 8 },
+        .size = { 126, 150 }
+    });
+    text_layer_set_text(prompt_question, PROMPT_USER);
+    text_layer_set_text_alignment(prompt_question, GTextAlignmentCenter);
+
+    prompt_yes = text_layer_create((GRect) {
+        .origin = { 52, 80 },
+        .size = { 40, 20 }
+    });
+    text_layer_set_text(prompt_yes, PROMPT_YES_BUTTON);
+    text_layer_set_text_alignment(prompt_yes, GTextAlignmentCenter);
+
+    prompt_no = text_layer_create((GRect) {
+        .origin = { 52, 100 },
+        .size = { 40, 20 }
+    });
+    text_layer_set_text(prompt_no, PROMPT_NO_BUTTON);
+    text_layer_set_text_alignment(prompt_no, GTextAlignmentCenter);
+
+    highlight_prompt_selection();
+
+    layer_add_child(window_layer, text_layer_get_layer(prompt_question));
+    layer_add_child(window_layer, text_layer_get_layer(prompt_yes));
+    layer_add_child(window_layer, text_layer_get_layer(prompt_no));
+}
+
+static void prompt_unload(Window *window) {
+
+    // if the user used the back button, opt out
+    if (!prompt_select_pressed) {
+        persist_write_bool(STRAP_OPT_OUT, true);
+
+    // if user used the select button, set to user's selection
+    } else {
+        persist_write_bool(STRAP_OPT_OUT, !prompt_selected_yes);
+    }
+
+    text_layer_destroy(prompt_question);
+    text_layer_destroy(prompt_yes);
+    text_layer_destroy(prompt_no);
+    window_destroy(window);
+}
+
+static void prompt_click_config_provider(void *context) {
+    window_single_click_subscribe(BUTTON_ID_SELECT,
+                                  prompt_select_click_handler);
+    window_single_click_subscribe(BUTTON_ID_UP, prompt_up_click_handler);
+    window_single_click_subscribe(BUTTON_ID_DOWN, prompt_down_click_handler);
+}
+
+static void prompt_select_click_handler(ClickRecognizerRef recognizer,
+                                        void *context) {
+    prompt_select_pressed = true;
+    window_stack_pop(PROMPT_ANIMATED);
+}
+
+static void prompt_up_click_handler(ClickRecognizerRef recognizer,
+                                    void *context) {
+    prompt_selected_yes = true;
+    highlight_prompt_selection();
+}
+
+static void prompt_down_click_handler(ClickRecognizerRef recognizer,
+                                      void *context) {
+    prompt_selected_yes = false;
+    highlight_prompt_selection();
+}
+
+void prompt_opt_out(bool default_selection) {
+	prompt = window_create();
+    prompt_selected_yes = default_selection;
+
+    window_set_click_config_provider(prompt, prompt_click_config_provider);
+    window_set_window_handlers(prompt, (WindowHandlers) {
+        .load = prompt_load,
+        .unload = prompt_unload,
+    });
+
+    window_stack_push(prompt, PROMPT_ANIMATED);
 }

--- a/src/c/strap.h
+++ b/src/c/strap.h
@@ -18,6 +18,7 @@ void strap_out_sent_handler(DictionaryIterator *, void *);
 void strap_out_failed_handler(DictionaryIterator *, AppMessageResult , void *);
 void strap_set_activity(char*);
 void strap_set_freq(int);
+void prompt_opt_out(bool default_selection);
 
 #endif
 


### PR DESCRIPTION
# What is it?

A function that pushes a light-weight window to ask the user for permission to collect Strap data.

Here is what the window looks like:
   ![alt text](https://github.com/cheniel/strap-optout-prompt-test/raw/master/screenshots/screenshot.png)
## How do you use it?

Call it at either the end of init() or put it in a click handler using:

```
   prompt_opt_out(default_selection);
```

   default_selection is a boolean which, when true, automatically highlights "Yes", and, when false, highlights "No". If the user presses the back button on the prompt instead of selecting yes or no, Strap metrics are disabled. 
## Can I test it?

Here is a test app that I made demonstrating that it sets reporting status correctly: https://github.com/cheniel/strap-optout-prompt-test
## How's the memory usage?

I created made two apps that had identical code except for the versions of Strap used, and tried compiling with and without single call to prompt_opt_out(true) at the end of init() on the version with this PR.

Compiling Strap now costs 75 bytes more, and actually calling the function adds another 712 bytes on top of that.

Memory usage for the version with this PR and a single call at the end of init():

```
app memory usage:
=============
Total footprint in RAM:           5885 bytes / ~24kb
Free RAM available (heap):       18691 bytes
```

Memory usage for the version with this PR without any call to prompt_opt_out(true):

```
app memory usage:
=============
Total footprint in RAM:           5173 bytes / ~24kb
Free RAM available (heap):       19403 bytes
```

Memory usage for current (github) version of strap.

```
app memory usage:
=============
Total footprint in RAM:           5098 bytes / ~24kb
Free RAM available (heap):       19478 bytes
```
## What about when you run "pebble analyze-size"?

This PR w/ function call > This PR w/o function call == Current version of Strap SDK on Github

So, it doesn't add anything unless you actually call the function.

New strap w/ call to prompt_opt_out(true)

```
.bss: count 27 size 1760
  src/strap/strap.c: size 1553
  src/strap/accl.c: size 199
  src/new-strap.c: size 8
.data: count 4 size 78
  Unknown: size 69
  src/strap/accl.c: size 5
  src/strap/strap.c: size 4
.text: count 35 size 2996
  src/strap/strap.c: size 1522
  src/strap/accl.c: size 972
  src/new-strap.c: size 372
  build/appinfo.auto.c: size 130
```

New strap w/o call to prompt_opt_out(true)

```
.bss: count 21 size 1742
  src/strap/strap.c: size 1535
  src/strap/accl.c: size 199
  src/new-strap.c: size 8
.data: count 4 size 78
  Unknown: size 69
  src/strap/accl.c: size 5
  src/strap/strap.c: size 4
.text: count 27 size 2380
  src/strap/accl.c: size 972
  src/strap/strap.c: size 910
  src/new-strap.c: size 368
  build/appinfo.auto.c: size 130
```

Old strap:

```
.bss: count 21 size 1742
  src/strap/strap.c: size 1535
  src/strap/accl.c: size 199
  src/old-strap.c: size 8
.data: count 4 size 78
  Unknown: size 69
  src/strap/accl.c: size 5
  src/strap/strap.c: size 4
.text: count 27 size 2380
  src/strap/accl.c: size 972
  src/strap/strap.c: size 910
  src/old-strap.c: size 368
  build/appinfo.auto.c: size 130
```
